### PR TITLE
Correct the link for Getting Started with SwiftUI Course in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains all the downloadable materials and projects associated with the **Introduction to SwiftUI** module in:
 
-### [Getting Started with SwiftUI Course](https://www.kodeco.com/library)
+### [Getting Started with SwiftUI Course](https://www.kodeco.com/ios/paths/getting-started-swiftui)
 
 - This course is part of [iOS Essentials Program](https://www.kodeco.com/ios/programs/ios-essentials), which you can take as either on-demand or live bootcamp from [Kodeco](https://www.kodeco.com).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo contains all the downloadable materials and projects associated with t
 
 ### [Getting Started with SwiftUI Course](https://www.kodeco.com/ios/paths/getting-started-swiftui)
 
-- This course is part of [iOS Essentials Program](https://www.kodeco.com/ios/programs/ios-essentials), which you can take as either on-demand or live bootcamp from [Kodeco](https://www.kodeco.com).
+- This course is part of [iOS Ready Program](https://www.kodeco.com/ios/programs/ios-ready), which you can take as either on-demand or live bootcamp from [Kodeco](https://www.kodeco.com).
 
 
 ---


### PR DESCRIPTION
Correct the link for `Getting Started with SwiftUI Course` in README.md